### PR TITLE
More testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TODO
     - [x] Add Integration testing
     - [x] Add fail case account controller testing
     - [x] Use httptest for tests instead of setting up an http server for each test
-        - [ ] Fix bug where connection is rejected (I sus due to db+http connection limitations in unix)
+        - [x] Fix bug where connection is rejected (I sus due to db+http connection limitations in unix)
     - [ ] Add cursor testing for listing accounts
     - [ ] Add fuzzing
     - [ ] Create a seeder for a basic dev environment of data

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Simple Accounting Ledger
 - Simple application which writes and reads accounting ledger entries
 
 TODO
+- [ ] use httpapi models for request/response of all resources
 - [ ] Testing
     - [x] Add more unit tests, solitary and sociable
     - [x] Add Integration testing
@@ -29,6 +30,7 @@ TODO
 - [ ] 011y
     - [ ] Add tracing
     - [ ] Add metrics
+- [x] decouple application runtime, environment, controller, and test!
 - [x] implement golang-migrate or similar db migration strategy
     - [x] include the sql files as bin data in binary so migrator can run them ez pz
 - [x] Complete the basic CRUD for book-keeping

--- a/api/entries.yml
+++ b/api/entries.yml
@@ -45,7 +45,7 @@ components:
           $ref: 'shared.yml#/components/schemas/uuid'
         description:
           type: string
-        debirAccount:
+        debitAccount:
           $ref: 'shared.yml#/components/schemas/uuid'
         creditAccount:
           $ref: 'shared.yml#/components/schemas/uuid'

--- a/api/transactions.yml
+++ b/api/transactions.yml
@@ -71,7 +71,7 @@ components:
       properties:
         description:
           type: string
-        debirAccount:
+        debitAccount:
           $ref: 'shared.yml#/components/schemas/uuid'
         creditAccount:
           $ref: 'shared.yml#/components/schemas/uuid'

--- a/cmd/goluca/main.go
+++ b/cmd/goluca/main.go
@@ -23,7 +23,7 @@ func main() {
 		log.Panic("failed to create new environment")
 	}
 
-	db, err := database.NewDatabasePool(env.Config.Database.ConnectionString())
+	db, err := database.NewDatabasePool(ctx, env.Config.Database.ConnectionString())
 	if err != nil {
 		env.Log.Error("creating new database pool", zap.Error(err))
 		log.Fatal("error creating database pool on application start")

--- a/cmd/goluca/main.go
+++ b/cmd/goluca/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"net/http"
 
 	"github.com/hampgoodwin/GoLuca/internal/environment"
 	"go.uber.org/zap"
@@ -15,7 +16,12 @@ func main() {
 		log.Panic("failed to create new environment")
 	}
 
-	s := environment.NewHTTPServer(env)
+	// s := environment.NewHTTPServer(env)
+	s := &http.Server{
+		Addr:     env.Config.HTTPAPI.AddressString(),
+		ErrorLog: zap.NewStdLog(env.Log),
+		Handler:  env.HTTPMux,
+	}
 
 	if err := s.ListenAndServe(); err != nil {
 		env.Log.Panic("http server failed", zap.Error(err))

--- a/go.mod
+++ b/go.mod
@@ -13,16 +13,13 @@ require (
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/matryer/is v1.4.0
 	github.com/pelletier/go-toml v1.9.4
-	github.com/stretchr/testify v1.7.0
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/golang-migrate/migrate/v4 v4.15.1
@@ -35,7 +32,6 @@ require (
 	github.com/jackc/pgtype v1.10.0 // indirect
 	github.com/jackc/puddle v1.2.1 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -669,13 +669,11 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq19sBYvuMoyQ4=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
@@ -846,7 +844,6 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
@@ -1475,7 +1472,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/internal/configloader/configloader_test.go
+++ b/internal/configloader/configloader_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-playground/validator"
 	"github.com/hampgoodwin/GoLuca/internal/config"
 	"github.com/hampgoodwin/errors"
-	"github.com/stretchr/testify/require"
+	"github.com/matryer/is"
 )
 
 func TestLoad(t *testing.T) {
@@ -154,7 +154,7 @@ func TestLoad(t *testing.T) {
 		},
 	}
 
-	a := require.New(t)
+	a := is.New(t)
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.description), func(t *testing.T) {
 			resetApplicationEnvironmentVariables()
@@ -166,12 +166,12 @@ func TestLoad(t *testing.T) {
 
 			actual, err := Load(tc.cfg, tc.filepath)
 			if tc.err != nil {
-				a.NotNil(err)
+				a.True(err != nil)
 				// Using errors.As because it detects validator.ValidationErrors
-				a.ErrorAs(err, &tc.err)
+				a.True(errors.As(err, &tc.err))
 				return
 			}
-			a.NoError(err)
+			a.NoErr(err)
 			a.Equal(tc.expected, actual)
 		})
 	}
@@ -225,17 +225,17 @@ func TestLoadConfigurationFile(t *testing.T) {
 		},
 	}
 
-	a := require.New(t)
+	a := is.New(t)
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.description), func(t *testing.T) {
 			actual, err := loadConfigurationFile(tc.filepath)
 			if tc.err != nil {
-				a.NotNil(err)
-				a.ErrorAs(err, &tc.err)
+				a.True(err != nil)
+				a.True(errors.As(err, &tc.err))
 				return
 			}
-			a.NoError(err)
+			a.NoErr(err)
 			a.Equal(tc.expected, actual)
 		})
 	}
@@ -304,7 +304,7 @@ func TestLoadEnvironmentVariables(t *testing.T) {
 		},
 	}
 
-	a := require.New(t)
+	a := is.New(t)
 	for i, tc := range testCases {
 		// clean the
 		t.Run(fmt.Sprintf("%d:%s", i, tc.description), func(t *testing.T) {

--- a/internal/controller/account.go
+++ b/internal/controller/account.go
@@ -12,15 +12,15 @@ import (
 	"go.uber.org/zap"
 )
 
-type AccountRequest struct {
+type accountRequest struct {
 	*account.Account `json:"account" validate:"required"`
 }
 
-type AccountResponse struct {
+type accountResponse struct {
 	*account.Account `json:"account" validate:"required"`
 }
 
-type AccountsResponse struct {
+type accountsResponse struct {
 	Accounts   []account.Account `json:"accounts" validated:"required"`
 	NextCursor string            `json:"nextCursor,omitempty" validated:"base64"`
 }
@@ -48,7 +48,7 @@ func (c *Controller) getAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res := &AccountResponse{Account: account}
+	res := &accountResponse{Account: account}
 	c.respond(w, res, http.StatusOK)
 }
 
@@ -68,13 +68,13 @@ func (c *Controller) getAccounts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res := &AccountsResponse{Accounts: accounts, NextCursor: *nextCursor}
+	res := &accountsResponse{Accounts: accounts, NextCursor: *nextCursor}
 	c.respond(w, res, http.StatusOK)
 }
 
 func (c *Controller) createAccount(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	req := &AccountRequest{}
+	req := &accountRequest{}
 	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
 		c.respondError(w, c.log, errors.WrapWithErrorMessage(err, errors.NotDeserializable, err.Error(), "deserializing request body"))
 		return
@@ -86,7 +86,7 @@ func (c *Controller) createAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res := AccountResponse{Account: created}
+	res := accountResponse{Account: created}
 	w.WriteHeader(http.StatusCreated)
 	c.respond(w, res, http.StatusCreated)
 }

--- a/internal/controller/account_test.go
+++ b/internal/controller/account_test.go
@@ -78,7 +78,7 @@ func TestCreateAccount_CannotDeserialize(t *testing.T) {
 	err := json.NewDecoder(res.Body).Decode(&errRes)
 	s.Is.NoErr(err)
 
-	s.Is.Equal("json: cannot unmarshal string into Go value of type AccountRequest", errRes.Description)
+	s.Is.Equal("json: cannot unmarshal string into Go value of type controller.accountRequest", errRes.Description)
 
 }
 

--- a/internal/controller/account_test.go
+++ b/internal/controller/account_test.go
@@ -193,7 +193,6 @@ func createAccount(
 	e interface{},
 ) *http.Response {
 	t.Helper()
-	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
 
 	var body = new(bytes.Buffer)
 	err := json.NewEncoder(body).Encode(e)

--- a/internal/controller/account_test.go
+++ b/internal/controller/account_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestCreateAccount(t *testing.T) {
 	s := test.GetScope(t)
+	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
 
-	aReq := AccountRequest{
+	aReq := accountRequest{
 		Account: &account.Account{
 			Name:  "cash",
 			Type:  account.Asset,
@@ -28,11 +29,11 @@ func TestCreateAccount(t *testing.T) {
 	res := createAccount(t, &s, aReq)
 	defer res.Body.Close()
 
-	var aRes AccountResponse
+	var aRes accountResponse
 	err := json.NewDecoder(res.Body).Decode(&aRes)
 	s.Is.NoErr(err)
 
-	s.Is.True(aRes != (AccountResponse{}))
+	s.Is.True(aRes != (accountResponse{}))
 
 	s.Is.Equal(aReq.Account.Name, aRes.Account.Name)
 	s.Is.Equal(aReq.Account.Type, aRes.Account.Type)
@@ -43,8 +44,9 @@ func TestCreateAccount(t *testing.T) {
 
 func TestCreateAccount_InvalidRequestBody(t *testing.T) {
 	s := test.GetScope(t)
+	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
 
-	aReq := AccountRequest{
+	aReq := accountRequest{
 		Account: &account.Account{
 			Name:  "",
 			Type:  account.Type("type"),
@@ -65,6 +67,7 @@ func TestCreateAccount_InvalidRequestBody(t *testing.T) {
 
 func TestCreateAccount_CannotDeserialize(t *testing.T) {
 	s := test.GetScope(t)
+	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
 
 	bad := []byte{}
 
@@ -81,9 +84,10 @@ func TestCreateAccount_CannotDeserialize(t *testing.T) {
 
 func TestGetAccount(t *testing.T) {
 	s := test.GetScope(t)
+	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
 
 	// Create an account and assert
-	aReq := AccountRequest{
+	aReq := accountRequest{
 		Account: &account.Account{
 			Name:  "cash",
 			Type:  account.Asset,
@@ -94,7 +98,7 @@ func TestGetAccount(t *testing.T) {
 	res := createAccount(t, &s, aReq)
 	defer res.Body.Close()
 
-	var aRes AccountResponse
+	var aRes accountResponse
 	err := json.NewDecoder(res.Body).Decode(&aRes)
 	s.Is.NoErr(err)
 
@@ -102,7 +106,7 @@ func TestGetAccount(t *testing.T) {
 	getRes := getAccount(t, &s, aRes.ID)
 	res.Body.Close()
 
-	var getARes AccountResponse
+	var getARes accountResponse
 	err = json.NewDecoder(getRes.Body).Decode(&getARes)
 	s.Is.NoErr(err)
 
@@ -111,6 +115,7 @@ func TestGetAccount(t *testing.T) {
 
 func TestGetAccount_ErrorNotFound(t *testing.T) {
 	s := test.GetScope(t)
+	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
 
 	id := uuid.NewString()
 	res := getAccount(t, &s, id)
@@ -123,6 +128,7 @@ func TestGetAccount_ErrorNotFound(t *testing.T) {
 
 func TestGetAccount_InvalidPersistedAccount(t *testing.T) {
 	s := test.GetScope(t)
+	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
 
 	id := gofakeit.Sentence(1)
 	parentID := gofakeit.Sentence(1)
@@ -144,9 +150,10 @@ func TestGetAccount_InvalidPersistedAccount(t *testing.T) {
 
 func TestGetAccounts(t *testing.T) {
 	s := test.GetScope(t)
+	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
 
 	// Create an account and assert
-	aReq := AccountRequest{
+	aReq := accountRequest{
 		Account: &account.Account{
 			Name:  "cash",
 			Type:  account.Asset,
@@ -156,7 +163,7 @@ func TestGetAccounts(t *testing.T) {
 	res := createAccount(t, &s, aReq)
 	defer res.Body.Close()
 
-	var a1 AccountResponse
+	var a1 accountResponse
 	err := json.NewDecoder(res.Body).Decode(&a1)
 	s.Is.NoErr(err)
 
@@ -164,7 +171,7 @@ func TestGetAccounts(t *testing.T) {
 	res2 := createAccount(t, &s, aReq)
 	defer res2.Body.Close()
 
-	var a2 AccountResponse
+	var a2 accountResponse
 	err = json.NewDecoder(res2.Body).Decode(&a2)
 	s.Is.NoErr(err)
 
@@ -186,6 +193,7 @@ func createAccount(
 	e interface{},
 ) *http.Response {
 	t.Helper()
+	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
 
 	var body = new(bytes.Buffer)
 	err := json.NewEncoder(body).Encode(e)
@@ -226,7 +234,7 @@ func getAccount(
 func getAccounts(
 	t *testing.T,
 	s *test.Scope,
-) AccountsResponse {
+) accountsResponse {
 	// Get the created account and assert it's equal to the created account
 	req, err := http.NewRequest(
 		http.MethodGet,
@@ -238,7 +246,7 @@ func getAccounts(
 	res, err := s.HTTPClient.Do(req)
 	s.Is.NoErr(err)
 
-	var aRes AccountsResponse
+	var aRes accountsResponse
 	err = json.NewDecoder(res.Body).Decode(&aRes)
 	s.Is.NoErr(err)
 

--- a/internal/controller/account_test.go
+++ b/internal/controller/account_test.go
@@ -1,4 +1,4 @@
-package controller_test
+package controller
 
 import (
 	"bytes"
@@ -10,7 +10,6 @@ import (
 
 	"github.com/brianvoe/gofakeit"
 	"github.com/google/uuid"
-	"github.com/hampgoodwin/GoLuca/internal/controller"
 	"github.com/hampgoodwin/GoLuca/internal/test"
 	"github.com/hampgoodwin/GoLuca/pkg/account"
 )
@@ -18,7 +17,7 @@ import (
 func TestCreateAccount(t *testing.T) {
 	s := test.GetScope(t)
 
-	aReq := controller.AccountRequest{
+	aReq := AccountRequest{
 		Account: &account.Account{
 			Name:  "cash",
 			Type:  account.Asset,
@@ -29,11 +28,11 @@ func TestCreateAccount(t *testing.T) {
 	res := createAccount(t, &s, aReq)
 	defer res.Body.Close()
 
-	var aRes controller.AccountResponse
+	var aRes AccountResponse
 	err := json.NewDecoder(res.Body).Decode(&aRes)
 	s.Is.NoErr(err)
 
-	s.Is.True(aRes != (controller.AccountResponse{}))
+	s.Is.True(aRes != (AccountResponse{}))
 
 	s.Is.Equal(aReq.Account.Name, aRes.Account.Name)
 	s.Is.Equal(aReq.Account.Type, aRes.Account.Type)
@@ -45,7 +44,7 @@ func TestCreateAccount(t *testing.T) {
 func TestCreateAccount_InvalidRequestBody(t *testing.T) {
 	s := test.GetScope(t)
 
-	aReq := controller.AccountRequest{
+	aReq := AccountRequest{
 		Account: &account.Account{
 			Name:  "",
 			Type:  account.Type("type"),
@@ -56,7 +55,7 @@ func TestCreateAccount_InvalidRequestBody(t *testing.T) {
 	res := createAccount(t, &s, aReq)
 	defer res.Body.Close()
 
-	var errRes controller.ErrorResponse
+	var errRes ErrorResponse
 	err := json.NewDecoder(res.Body).Decode(&errRes)
 	s.Is.NoErr(err)
 
@@ -72,11 +71,11 @@ func TestCreateAccount_CannotDeserialize(t *testing.T) {
 	res := createAccount(t, &s, bad)
 	defer res.Body.Close()
 
-	var errRes controller.ErrorResponse
+	var errRes ErrorResponse
 	err := json.NewDecoder(res.Body).Decode(&errRes)
 	s.Is.NoErr(err)
 
-	s.Is.Equal("json: cannot unmarshal string into Go value of type controller.AccountRequest", errRes.Description)
+	s.Is.Equal("json: cannot unmarshal string into Go value of type AccountRequest", errRes.Description)
 
 }
 
@@ -84,7 +83,7 @@ func TestGetAccount(t *testing.T) {
 	s := test.GetScope(t)
 
 	// Create an account and assert
-	aReq := controller.AccountRequest{
+	aReq := AccountRequest{
 		Account: &account.Account{
 			Name:  "cash",
 			Type:  account.Asset,
@@ -95,7 +94,7 @@ func TestGetAccount(t *testing.T) {
 	res := createAccount(t, &s, aReq)
 	defer res.Body.Close()
 
-	var aRes controller.AccountResponse
+	var aRes AccountResponse
 	err := json.NewDecoder(res.Body).Decode(&aRes)
 	s.Is.NoErr(err)
 
@@ -103,7 +102,7 @@ func TestGetAccount(t *testing.T) {
 	getRes := getAccount(t, &s, aRes.ID)
 	res.Body.Close()
 
-	var getARes controller.AccountResponse
+	var getARes AccountResponse
 	err = json.NewDecoder(getRes.Body).Decode(&getARes)
 	s.Is.NoErr(err)
 
@@ -116,7 +115,7 @@ func TestGetAccount_ErrorNotFound(t *testing.T) {
 	id := uuid.NewString()
 	res := getAccount(t, &s, id)
 
-	var errRes controller.ErrorResponse
+	var errRes ErrorResponse
 	err := json.NewDecoder(res.Body).Decode(&errRes)
 	s.Is.NoErr(err)
 	s.Is.Equal(fmt.Sprintf("account %q not found", id), errRes.Description)
@@ -147,7 +146,7 @@ func TestGetAccounts(t *testing.T) {
 	s := test.GetScope(t)
 
 	// Create an account and assert
-	aReq := controller.AccountRequest{
+	aReq := AccountRequest{
 		Account: &account.Account{
 			Name:  "cash",
 			Type:  account.Asset,
@@ -157,7 +156,7 @@ func TestGetAccounts(t *testing.T) {
 	res := createAccount(t, &s, aReq)
 	defer res.Body.Close()
 
-	var a1 controller.AccountResponse
+	var a1 AccountResponse
 	err := json.NewDecoder(res.Body).Decode(&a1)
 	s.Is.NoErr(err)
 
@@ -165,7 +164,7 @@ func TestGetAccounts(t *testing.T) {
 	res2 := createAccount(t, &s, aReq)
 	defer res2.Body.Close()
 
-	var a2 controller.AccountResponse
+	var a2 AccountResponse
 	err = json.NewDecoder(res2.Body).Decode(&a2)
 	s.Is.NoErr(err)
 
@@ -227,7 +226,7 @@ func getAccount(
 func getAccounts(
 	t *testing.T,
 	s *test.Scope,
-) controller.AccountsResponse {
+) AccountsResponse {
 	// Get the created account and assert it's equal to the created account
 	req, err := http.NewRequest(
 		http.MethodGet,
@@ -239,7 +238,7 @@ func getAccounts(
 	res, err := s.HTTPClient.Do(req)
 	s.Is.NoErr(err)
 
-	var aRes controller.AccountsResponse
+	var aRes AccountsResponse
 	err = json.NewDecoder(res.Body).Decode(&aRes)
 	s.Is.NoErr(err)
 

--- a/internal/controller/test.go
+++ b/internal/controller/test.go
@@ -1,0 +1,21 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/hampgoodwin/GoLuca/internal/repository"
+	"github.com/hampgoodwin/GoLuca/internal/router"
+	"github.com/hampgoodwin/GoLuca/internal/service"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"go.uber.org/zap"
+)
+
+func newTestHTTPHandler(
+	log *zap.Logger,
+	db *pgxpool.Pool,
+) http.Handler {
+	r := repository.NewRepository(db)
+	s := service.NewService(log, r)
+	c := NewController(log, s)
+	return router.Register(log, c.RegisterAccountRoutes)
+}

--- a/internal/controller/test.go
+++ b/internal/controller/test.go
@@ -17,5 +17,9 @@ func newTestHTTPHandler(
 	r := repository.NewRepository(db)
 	s := service.NewService(log, r)
 	c := NewController(log, s)
-	return router.Register(log, c.RegisterAccountRoutes)
+	return router.Register(
+		log,
+		c.RegisterAccountRoutes,
+		c.RegisterTransactionRoutes,
+	)
 }

--- a/internal/controller/transaction_test.go
+++ b/internal/controller/transaction_test.go
@@ -1,0 +1,99 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/hampgoodwin/GoLuca/internal/httpapi"
+	"github.com/hampgoodwin/GoLuca/internal/test"
+	"github.com/hampgoodwin/GoLuca/pkg/account"
+	"github.com/hampgoodwin/GoLuca/pkg/amount"
+)
+
+func TestCreateTransaction(t *testing.T) {
+	s := test.GetScope(t)
+	s.SetHTTP(t, newTestHTTPHandler(s.Env.Log, s.DB))
+
+	aReq := accountRequest{
+		Account: &account.Account{
+			Name:  "cash",
+			Type:  account.Asset,
+			Basis: "debit",
+		},
+	}
+	res := createAccount(t, &s, aReq)
+	defer res.Body.Close()
+	var aRes accountResponse
+	err := json.NewDecoder(res.Body).Decode(&aRes)
+	s.Is.NoErr(err)
+	cashAccount := aRes.Account
+
+	aReq = accountRequest{
+		Account: &account.Account{
+			Name:  "revenue",
+			Type:  account.Asset,
+			Basis: "credit",
+		},
+	}
+	res2 := createAccount(t, &s, aReq)
+	defer res2.Body.Close()
+	err = json.NewDecoder(res2.Body).Decode(&aRes)
+	s.Is.NoErr(err)
+	revenueAccount := aRes.Account
+
+	tReq := transactionRequest{
+		Transaction: httpapi.Transaction{
+			Description: "test",
+			Entries: []httpapi.Entry{
+				{
+					Description:   "",
+					DebitAccount:  cashAccount.ID,
+					CreditAccount: revenueAccount.ID,
+					Amount: httpapi.Amount{
+						Value:    "100",
+						Currency: "USD",
+					},
+				},
+			},
+		},
+	}
+
+	res3 := createTransaction(t, &s, tReq)
+	defer res3.Body.Close()
+
+	var tRes transactionResponse
+	err = json.NewDecoder(res3.Body).Decode(&tRes)
+	s.Is.NoErr(err)
+
+	s.Is.True(tRes != (transactionResponse{}))
+
+	s.Is.True(tRes.Entries[0].CreditAccount == revenueAccount.ID)
+	s.Is.True(tRes.Entries[0].DebitAccount == cashAccount.ID)
+	s.Is.True(tRes.Entries[0].Amount == amount.Amount{Value: 100, Currency: "USD"})
+}
+
+func createTransaction(
+	t *testing.T,
+	s *test.Scope,
+	e interface{},
+) *http.Response {
+	t.Helper()
+
+	var body = new(bytes.Buffer)
+	err := json.NewEncoder(body).Encode(e)
+	s.Is.NoErr(err)
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		s.HTTPTestServer.URL+"/transactions",
+		body,
+	)
+	s.Is.NoErr(err)
+
+	res, err := s.HTTPClient.Do(req)
+	s.Is.NoErr(err)
+
+	return res
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -18,8 +18,7 @@ import (
 var migrations embed.FS
 
 // NewDatabasePool creates a new DB
-func NewDatabasePool(connString string) (*pgxpool.Pool, error) {
-	ctx := context.Background()
+func NewDatabasePool(ctx context.Context, connString string) (*pgxpool.Pool, error) {
 	var err error
 	DBPool, err := pgxpool.Connect(ctx, connString)
 	if err != nil {

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -1,12 +1,8 @@
 package environment
 
 import (
-	"net/http"
-
-	"github.com/go-chi/chi"
 	"github.com/hampgoodwin/GoLuca/internal/config"
 	"github.com/hampgoodwin/GoLuca/internal/configloader"
-	"github.com/hampgoodwin/GoLuca/internal/controller"
 	"github.com/hampgoodwin/GoLuca/internal/database"
 	"github.com/hampgoodwin/GoLuca/internal/repository"
 	"github.com/hampgoodwin/GoLuca/internal/service"
@@ -23,8 +19,8 @@ type Environment struct {
 	Log    *zap.Logger
 
 	// API: HTTPServer and controllers
-	HTTPMux    *chi.Mux
-	controller *controller.Controller
+	// HTTPMux    *chi.Mux
+	// controller *controller.Controller
 
 	// service
 	service *service.Service
@@ -101,21 +97,21 @@ func New(e Environment, fp string) (Environment, error) {
 	}
 
 	// Controllers
-	if env.controller == nil {
-		env, err = SetController(env, env.service)
-		if err != nil {
-			return env, errors.Wrap(err, "setting environment controller")
-		}
-	}
+	// if env.controller == nil {
+	// 	env, err = SetController(env, env.service)
+	// 	if err != nil {
+	// 		return env, errors.Wrap(err, "setting environment controller")
+	// 	}
+	// }
 
 	// register routes
-	if env.HTTPMux == nil {
-		env.HTTPMux = controller.Register(
-			env.Log,
-			env.controller.RegisterAccountRoutes,
-			env.controller.RegisterTransactionRoutes,
-		)
-	}
+	// if env.HTTPMux == nil {
+	// env.HTTPMux = controller.Register(
+	// 	env.Log,
+	// 	env.controller.RegisterAccountRoutes,
+	// 	env.controller.RegisterTransactionRoutes,
+	// )
+	// }
 
 	return env, nil
 }
@@ -157,19 +153,19 @@ func SetService(env Environment, r *repository.Repository) (Environment, error) 
 	return env, nil
 }
 
-func SetController(env Environment, s *service.Service) (Environment, error) {
-	if s == nil {
-		return env, errors.New("cannot set environment controller without service")
-	}
-	env.controller = controller.NewController(env.Log, s)
-	return env, nil
-}
+// func SetController(env Environment, s *service.Service) (Environment, error) {
+// 	if s == nil {
+// 		return env, errors.New("cannot set environment controller without service")
+// 	}
+// 	env.controller = controller.NewController(env.Log, s)
+// 	return env, nil
+// }
 
-func NewHTTPServer(env Environment) *http.Server {
-	s := &http.Server{
-		Addr:     env.Config.HTTPAPI.AddressString(),
-		ErrorLog: zap.NewStdLog(env.Log),
-		Handler:  env.HTTPMux,
-	}
-	return s
-}
+// func NewHTTPServer(env Environment) *http.Server {
+// 	s := &http.Server{
+// 		Addr:     env.Config.HTTPAPI.AddressString(),
+// 		ErrorLog: zap.NewStdLog(env.Log),
+// 		Handler:  env.HTTPMux,
+// 	}
+// 	return s
+// }

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -3,31 +3,14 @@ package environment
 import (
 	"github.com/hampgoodwin/GoLuca/internal/config"
 	"github.com/hampgoodwin/GoLuca/internal/configloader"
-	"github.com/hampgoodwin/GoLuca/internal/database"
-	"github.com/hampgoodwin/GoLuca/internal/repository"
-	"github.com/hampgoodwin/GoLuca/internal/service"
-	"github.com/hampgoodwin/errors"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"go.uber.org/zap"
 
-	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
 type Environment struct {
 	Config config.Config
 	Log    *zap.Logger
-
-	// API: HTTPServer and controllers
-	// HTTPMux    *chi.Mux
-	// controller *controller.Controller
-
-	// service
-	service *service.Service
-
-	// DATA: database and repo
-	database   *pgxpool.Pool
-	repository *repository.Repository
 }
 
 func New(e Environment, fp string) (Environment, error) {
@@ -66,106 +49,5 @@ func New(e Environment, fp string) (Environment, error) {
 			zap.String("environment", env.Config.Environment.Type))
 	}
 
-	// Database
-	if env.database == nil {
-		db, err := database.NewDatabasePool(env.Config.Database.ConnectionString())
-		if err != nil {
-			env.Log.Fatal("creating new database pool", zap.Error(err))
-		}
-		env, err = SetDatabase(env, db)
-		if err != nil {
-			env.Log.Fatal("setting new database", zap.Error(err))
-		}
-		if err := MigrateDatabase(env); err != nil {
-			env.Log.Fatal("migrating database", zap.Error(err))
-		}
-	}
-
-	if env.repository == nil {
-		env, err = SetRepository(env, env.database)
-		if err != nil {
-			return env, errors.Wrap(err, "setting environment repository")
-		}
-	}
-
-	// Service
-	if env.service == nil {
-		env, err = SetService(env, env.repository)
-		if err != nil {
-			return env, errors.Wrap(err, "setting environment service")
-		}
-	}
-
-	// Controllers
-	// if env.controller == nil {
-	// 	env, err = SetController(env, env.service)
-	// 	if err != nil {
-	// 		return env, errors.Wrap(err, "setting environment controller")
-	// 	}
-	// }
-
-	// register routes
-	// if env.HTTPMux == nil {
-	// env.HTTPMux = controller.Register(
-	// 	env.Log,
-	// 	env.controller.RegisterAccountRoutes,
-	// 	env.controller.RegisterTransactionRoutes,
-	// )
-	// }
-
 	return env, nil
 }
-
-func SetDatabase(env Environment, db *pgxpool.Pool) (Environment, error) {
-	env.database = db
-	return env, nil
-}
-
-func MigrateDatabase(env Environment) error {
-	if err := database.Migrate(env.database); err != nil {
-		if !errors.Is(err, migrate.ErrNoChange) {
-			env.Log.Fatal("migrating", zap.Error(err))
-		}
-		env.Log.Info("no migration changes")
-		return nil
-	}
-	env.Log.Info("migration successful")
-	return nil
-}
-
-func CloseDatabase(env Environment) {
-	env.database.Close()
-}
-
-func SetRepository(env Environment, db *pgxpool.Pool) (Environment, error) {
-	if db == nil {
-		return env, errors.New("cannot set environment repository without database")
-	}
-	env.repository = repository.NewRepository(db)
-	return env, nil
-}
-
-func SetService(env Environment, r *repository.Repository) (Environment, error) {
-	if r == nil {
-		return env, errors.New("cannot set environment service without repository")
-	}
-	env.service = service.NewService(env.Log, r)
-	return env, nil
-}
-
-// func SetController(env Environment, s *service.Service) (Environment, error) {
-// 	if s == nil {
-// 		return env, errors.New("cannot set environment controller without service")
-// 	}
-// 	env.controller = controller.NewController(env.Log, s)
-// 	return env, nil
-// }
-
-// func NewHTTPServer(env Environment) *http.Server {
-// 	s := &http.Server{
-// 		Addr:     env.Config.HTTPAPI.AddressString(),
-// 		ErrorLog: zap.NewStdLog(env.Log),
-// 		Handler:  env.HTTPMux,
-// 	}
-// 	return s
-// }

--- a/internal/router/logger.go
+++ b/internal/router/logger.go
@@ -1,4 +1,4 @@
-package controller
+package router
 
 import (
 	"net/http"

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,4 +1,4 @@
-package controller
+package router
 
 import (
 	"time"

--- a/internal/test/environment_test.go
+++ b/internal/test/environment_test.go
@@ -7,9 +7,7 @@ import (
 )
 
 func TestNewTestEnvironment(t *testing.T) {
-	s, err := NewScope(t)
-	s.Is.NoErr(err)
+	s := GetScope(t)
 	s.Is.True(s != (Scope{}))
 	s.Is.Equal(config.Local, s.Env.Config)
-	s.Is.NoErr(err)
 }

--- a/internal/test/environment_test.go
+++ b/internal/test/environment_test.go
@@ -4,14 +4,12 @@ import (
 	"testing"
 
 	"github.com/hampgoodwin/GoLuca/internal/config"
-	"github.com/matryer/is"
 )
 
 func TestNewTestEnvironment(t *testing.T) {
-	i := is.New(t)
 	s, err := NewScope(t)
-	i.NoErr(err)
-	i.True(s != (Scope{}))
-	i.Equal(config.Local, s.Env.Config)
-	i.NoErr(err)
+	s.Is.NoErr(err)
+	s.Is.True(s != (Scope{}))
+	s.Is.Equal(config.Local, s.Env.Config)
+	s.Is.NoErr(err)
 }

--- a/internal/test/environment_test.go
+++ b/internal/test/environment_test.go
@@ -1,13 +1,47 @@
 package test
 
 import (
+	"context"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/hampgoodwin/GoLuca/internal/config"
 )
 
-func TestNewTestEnvironment(t *testing.T) {
+func TestGetScope(t *testing.T) {
 	s := GetScope(t)
 	s.Is.True(s != (Scope{}))
 	s.Is.Equal(config.Local, s.Env.Config)
+}
+
+func TestNewScope(t *testing.T) {
+	s, err := NewScope(t)
+	s.Is.NoErr(err)
+	s.Is.True(s != (Scope{}))
+}
+func TestNewDatabase_ContextCanceled(t *testing.T) {
+	s, err := NewScope(t)
+	s.Is.NoErr(err)
+	s.Is.True(s != (Scope{}))
+	ctx, done := context.WithCancel(s.Ctx)
+	s.Ctx = ctx
+	done()
+
+	err = s.NewDatabase(t)
+	s.Is.True(strings.Contains(err.Error(), "context canceled"))
+}
+
+func TestNewScope_SetHTTP(t *testing.T) {
+	s, err := NewScope(t)
+	s.Is.NoErr(err)
+	s.Is.True(s != (Scope{}))
+
+	mux := http.NewServeMux()
+
+	s.SetHTTP(t, mux)
+
+	r, err := http.Get(s.HTTPTestServer.URL)
+	s.Is.NoErr(err)
+	s.Is.True(r != nil)
 }

--- a/internal/test/scope.go
+++ b/internal/test/scope.go
@@ -60,6 +60,7 @@ func NewScope(t *testing.T) (Scope, error) {
 }
 
 func (s *Scope) NewDatabase(t *testing.T) error {
+	t.Helper()
 	// Get a random name for a database
 	gofakeit.Seed(0)
 	s.dbDatabase = strings.ToLower(strings.Replace(gofakeit.Name(), " ", "", -1))
@@ -94,6 +95,7 @@ func (s *Scope) NewDatabase(t *testing.T) error {
 }
 
 func (s *Scope) SetHTTP(t *testing.T, handler http.Handler) {
+	t.Helper()
 	s.HTTPTestServer = httptest.NewServer(handler)
 	s.HTTPClient = &http.Client{Timeout: time.Second * 30}
 }

--- a/internal/test/scope.go
+++ b/internal/test/scope.go
@@ -94,7 +94,7 @@ func NewScope(t *testing.T) (Scope, error) {
 		return s, errors.Wrap(err, "setting up new environment")
 	}
 
-	s.HTTPTestServer = httptest.NewServer(s.Env.HTTPMux)
+	// s.HTTPTestServer = httptest.NewServer(s.Env.HTTPMux)
 
 	t.Cleanup(func() { s.CleanupScope(t) })
 	return s, nil

--- a/internal/test/scope.go
+++ b/internal/test/scope.go
@@ -46,6 +46,7 @@ func GetScope(t *testing.T) Scope {
 func NewScope(t *testing.T) (Scope, error) {
 	s := Scope{}
 	s.Ctx = context.Background()
+
 	s.Env = environment.TestEnvironment
 	s.Env.Log = zap.NewNop()
 	s.Is = is.New(t)
@@ -66,7 +67,7 @@ func (s *Scope) NewDatabase(t *testing.T) error {
 	s.dbDatabase = strings.ToLower(strings.Replace(gofakeit.Name(), " ", "", -1))
 	var err error
 	// Create a connection pool on the default database
-	s.DB, err = database.NewDatabasePool(s.Env.Config.Database.ConnectionString())
+	s.DB, err = database.NewDatabasePool(s.Ctx, s.Env.Config.Database.ConnectionString())
 	if err != nil {
 		return errors.Wrap(err, "opening new database connection")
 	}
@@ -81,7 +82,7 @@ func (s *Scope) NewDatabase(t *testing.T) error {
 	// Open a connection to the newly created random database
 	dbCFG := s.Env.Config.Database
 	dbCFG.Database = s.dbDatabase
-	s.DB, err = database.NewDatabasePool(dbCFG.ConnectionString())
+	s.DB, err = database.NewDatabasePool(s.Ctx, dbCFG.ConnectionString())
 	if err != nil {
 		return errors.Wrap(err, "opening new database connection")
 	}
@@ -108,7 +109,7 @@ func (s *Scope) CleanupScope(t *testing.T) {
 		s.HTTPTestServer.Close()
 	}
 
-	db, _ := database.NewDatabasePool(s.Env.Config.Database.ConnectionString())
+	db, _ := database.NewDatabasePool(s.Ctx, s.Env.Config.Database.ConnectionString())
 	err := database.DropDatabase(db, s.dbDatabase)
 	s.Is.NoErr(err)
 }

--- a/internal/transformer/amount_test.go
+++ b/internal/transformer/amount_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hampgoodwin/GoLuca/internal/httpapi"
 	"github.com/hampgoodwin/GoLuca/pkg/amount"
 	"github.com/hampgoodwin/errors"
-	"github.com/stretchr/testify/require"
+	"github.com/matryer/is"
 )
 
 func TestNewAmountFromHTTPAmount(t *testing.T) {
@@ -42,7 +42,7 @@ func TestNewAmountFromHTTPAmount(t *testing.T) {
 		},
 	}
 
-	a := require.New(t)
+	a := is.New(t)
 
 	for i, tc := range testCases {
 		tc := tc
@@ -50,11 +50,10 @@ func TestNewAmountFromHTTPAmount(t *testing.T) {
 			t.Parallel()
 			actual, err := NewAmountFromHTTPAmount(tc.httpamount)
 			if err != nil {
-				a.Error(err)
 				a.True(errors.As(err, &tc.err))
 				return
 			}
-			a.NoError(err)
+			a.NoErr(err)
 			a.Equal(tc.expected, actual)
 		})
 	}

--- a/internal/transformer/transaction_test.go
+++ b/internal/transformer/transaction_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hampgoodwin/GoLuca/pkg/amount"
 	"github.com/hampgoodwin/GoLuca/pkg/transaction"
 	"github.com/hampgoodwin/errors"
-	"github.com/stretchr/testify/require"
+	"github.com/matryer/is"
 )
 
 func TestNewTransactionFromHTTPTransaction(t *testing.T) {
@@ -57,18 +57,18 @@ func TestNewTransactionFromHTTPTransaction(t *testing.T) {
 		},
 	}
 
-	a := require.New(t)
+	a := is.New(t)
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("%d:%s", i, tc.description), func(t *testing.T) {
 			t.Parallel()
 			actual, err := NewTransactionFromHTTPTransaction(tc.httpTransaction)
 			if tc.err != nil {
-				a.Error(err)
+				a.True(err != nil)
 				a.True(errors.Is(err, tc.err))
 				return
 			}
-			a.NoError(err)
+			a.NoErr(err)
 			a.Equal(tc.expected, actual)
 		})
 	}


### PR DESCRIPTION
# Changes

### Big wins

- Move creating an "environment" into the goluca main
- Remove _test from account_test.go
- Removed cyclical dependency between test<->environment<->controller 

### Smol wins

- Fixed typos in api doc generation
- use matryer/is over testify/require
- shrunk controller.Account API!

---

# Why

- I want an environment to hold information about the environment, not the environment itself
- Whatever is using an environment can easily enough create each piece of an environment it could need (http in this case)
  - This frees up creating more executables running against same dependencies (db) but initiating/instantiating only pieces applicable to what it wants to run. For ex, building another cmd to easily run nats, or composing nats to run in the goluca main.go cmd will now be easy. Composition! :D
- I did not like that the controller had to expose it's request/response data models. Those models shouldn't need to be exported, and they only were for testing purposes. The API should not be defined for a test.